### PR TITLE
Expose DeviceError event handler

### DIFF
--- a/Anviz.SDK/AnvizDevice.cs
+++ b/Anviz.SDK/AnvizDevice.cs
@@ -13,6 +13,7 @@ namespace Anviz.SDK
 
         public event EventHandler DevicePing;
         public event EventHandler<Response> ReceivedPacket;
+        public event EventHandler<Exception> DeviceError;
 
         public AnvizDevice(TcpClient socket)
         {
@@ -27,6 +28,10 @@ namespace Anviz.SDK
                 {
                     ReceivedPacket?.Invoke(this, e);
                 }
+            };
+            DeviceStream.DeviceError += (s, e) =>
+            {
+                DeviceError?.Invoke(this, e);
             };
         }
 

--- a/Anviz.SDK/AnvizStream.cs
+++ b/Anviz.SDK/AnvizStream.cs
@@ -20,6 +20,7 @@ namespace Anviz.SDK
         private TaskCompletionSource<Response> taskEmitter;
 
         public event EventHandler<Response> ReceivedPacket;
+        public event EventHandler<Exception> DeviceError;
 
         public AnvizStream(TcpClient socket)
         {
@@ -42,7 +43,15 @@ namespace Anviz.SDK
         {
             while (!CancellationTokenSource.IsCancellationRequested)
             {
-                var response = await Response.FromStream(DeviceStream, CancellationTokenSource.Token);
+                Response response = null;
+                try
+                {
+                    response = await Response.FromStream(DeviceStream, CancellationTokenSource.Token);
+                }
+                catch (Exception ex)
+                {
+                    DeviceError?.Invoke(this, ex);
+                }
                 if (response == null)
                 {
                     DeviceSocket.Close();

--- a/Sample/Program.cs
+++ b/Sample/Program.cs
@@ -27,6 +27,7 @@ namespace Sample
             {
                 device.DevicePing += (s, e) => Console.WriteLine("Device Ping Received");
                 device.ReceivedPacket += (s, e) => Console.WriteLine("Received packet");
+                device.DeviceError += (s, e) => throw e;
                 var id = await device.GetDeviceID();
                 var sn = await device.GetDeviceSN();
                 var type = await device.GetDeviceTypeCode();


### PR DESCRIPTION
Helps #37: instead of throwing, a new event is exposed to handle network errors